### PR TITLE
feat: remove x-internal-refresh header

### DIFF
--- a/src/modules/auth/login/infrastructure/endpoints/api/auth.endpoints.ts
+++ b/src/modules/auth/login/infrastructure/endpoints/api/auth.endpoints.ts
@@ -1,0 +1,5 @@
+export enum ApiAuthEndpoints {
+  LOGIN = '/auth/login',
+  REFRESH_ACCESS_TOKEN = '/auth/refresh-access-token',
+  VALIDATE_ACCESS_TOKEN = '/auth/validate-access-token',
+}

--- a/src/modules/auth/login/infrastructure/repositories/api-auth.repository.ts
+++ b/src/modules/auth/login/infrastructure/repositories/api-auth.repository.ts
@@ -7,12 +7,7 @@ import { UserAuthenticatedDto } from '../dtos/user-authenticated.dto';
 import { UnauthorizedException } from '../../domain/exceptions';
 import { HttpClientException } from 'src/modules/common/http/domain/exceptions/http-client.exception';
 import { UserEntityMapper } from 'src/modules/user/infrastructure/mappers/user-entity.mapper';
-
-enum ApiAuthRoutes {
-  Login = '/auth/login',
-  RefreshAccessToken = '/auth/refresh-access-token',
-  ValidateAccessToken = '/auth/validate-access-token',
-}
+import { ApiAuthEndpoints } from '../endpoints/api/auth.endpoints';
 
 @injectable()
 export class ApiAuthRepository extends AuthRepository {
@@ -21,7 +16,7 @@ export class ApiAuthRepository extends AuthRepository {
   }
 
   async login(email: string, password: string): Promise<{ user: UserEntity; accessToken: string }> {
-    const result = await this.httpClient.post<UserAuthenticatedDto>(ApiAuthRoutes.Login, {
+    const result = await this.httpClient.post<UserAuthenticatedDto>(ApiAuthEndpoints.LOGIN, {
       email,
       password,
     });
@@ -36,13 +31,8 @@ export class ApiAuthRepository extends AuthRepository {
 
   async refreshAccessToken(): Promise<{ user: UserEntity; accessToken: string }> {
     const result = await this.httpClient.post<UserAuthenticatedDto>(
-      ApiAuthRoutes.RefreshAccessToken,
+      ApiAuthEndpoints.REFRESH_ACCESS_TOKEN,
       {},
-      {
-        headers: {
-          'X-Internal-Refresh': 'true',
-        },
-      },
     );
 
     const userEntity = UserEntityMapper.toEntity(result.user);
@@ -56,7 +46,7 @@ export class ApiAuthRepository extends AuthRepository {
   async validateAccessToken(): Promise<{ user: UserEntity; accessToken: string }> {
     try {
       const result = await this.httpClient.post<UserAuthenticatedDto>(
-        ApiAuthRoutes.ValidateAccessToken,
+        ApiAuthEndpoints.VALIDATE_ACCESS_TOKEN,
         {},
       );
 

--- a/src/modules/common/http/domain/HttpClient.ts
+++ b/src/modules/common/http/domain/HttpClient.ts
@@ -1,14 +1,10 @@
-export enum HttpClientRequestConfigHeaders {
-  'X-Internal-Refresh' = 'X-Internal-Refresh',
-}
-
-export interface HttpClientRequestConfig {
-  headers: Record<HttpClientRequestConfigHeaders, string>;
-}
-
 export abstract class HttpClient {
   abstract get<T>(url: string, params?: object): Promise<T>;
-  abstract post<T>(url: string, body: object, config?: HttpClientRequestConfig): Promise<T>;
+  abstract post<T>(
+    url: string,
+    body: object,
+    config?: { headers: Record<string, string> },
+  ): Promise<T>;
   abstract put<T>(url: string, body: object): Promise<T>;
   abstract delete<T>(url: string): Promise<T>;
 }

--- a/src/modules/common/http/infrastructure/flows/refresh-access-token.flow.ts
+++ b/src/modules/common/http/infrastructure/flows/refresh-access-token.flow.ts
@@ -10,6 +10,7 @@ export async function handleRefreshTokenFlow(): Promise<string | null> {
 
   try {
     const { accessToken, user } = await refreshAccessTokenUseCase.handle();
+    console.log({ accessToken, user });
     authStore.login(user, accessToken);
     return accessToken;
   } catch {


### PR DESCRIPTION
Anteriormente se usaba el header X-Internal-Refresh para validar si se debía reintentar una petición al backend. Esto era útil para cuando una petición fallaba por token de acceso expirado pues se solicitaba uno nuevo mediante refresh token, sin embargo esta práctica era peligrosa pues el refresh token persistía en el navegador del usuario aunque se cerrara sesión.

Con este cambio, lo que hacemos ahora es validar la petición, y la clasificamos como si se debería reintentar o no.